### PR TITLE
refactor: removed terms and conditions from registration

### DIFF
--- a/the-pack/src/components/client/form/ClientRegister.tsx
+++ b/the-pack/src/components/client/form/ClientRegister.tsx
@@ -184,20 +184,6 @@ const ClientRegisterForm = () =>{
 
                     </div>
 
-                    <div className="flex items-center mt-6">
-
-                            <input 
-                            id="remember-me" 
-                            name="remember-me" 
-                            type="checkbox" 
-                            className="h-4 w-4 shrink-0 rounded" />
-
-                            <label htmlFor="remember-me" className="ml-3 block text-sm text-gray-300">
-                                I accept the <a href="javascript:void(0);" className="text-white font-semibold hover:underline ml-1">Terms and Conditions</a>
-                            </label>
-
-                    </div>
-
                     <div className="mt-12">
 
                         <button type="submit" className="w-full py-3 px-6 text-sm tracking-wide font-semibold rounded-md bg-white hover:bg-gray-400 text-black focus:outline-none">

--- a/the-pack/src/components/coach/forms/CoachRegister.tsx
+++ b/the-pack/src/components/coach/forms/CoachRegister.tsx
@@ -240,20 +240,6 @@ const CoachRegisterForm = () =>{
 
                     </div>
 
-                    <div className="flex items-center mt-6">
-
-                            <input 
-                            id="remember-me" 
-                            name="remember-me" 
-                            type="checkbox" 
-                            className="h-4 w-4 shrink-0 rounded" />
-
-                            <label htmlFor="remember-me" className="ml-3 block text-sm text-gray-300">
-                                I accept the <a href="javascript:void(0);" className="text-white font-semibold hover:underline ml-1">Terms and Conditions</a>
-                            </label>
-
-                    </div>
-
                     <div className="mt-12">
 
                         <button type="submit" className="w-full py-3 px-6 text-sm tracking-wide font-semibold rounded-md bg-white hover:bg-gray-400 text-black focus:outline-none">


### PR DESCRIPTION
This pull request includes changes to the registration forms for both clients and coaches in the `the-pack` application. The main focus is the removal of the "Terms and Conditions" acceptance checkbox from both forms.

Changes to registration forms:
* [`the-pack/src/components/client/form/ClientRegister.tsx`](diffhunk://#diff-ce4df4e6e81524dc5def05f111e0fc0c79c90c5c364a6e6ea8331ce6e0013547L187-L200): Removed the "Terms and Conditions" acceptance checkbox and its associated label from the client registration form.
* [`the-pack/src/components/coach/forms/CoachRegister.tsx`](diffhunk://#diff-8265a44089eb8b2c6df6e1d71ec61dd823e7bc529dbbba59ce791dfe11ca3fd1L243-L256): Removed the "Terms and Conditions" acceptance checkbox and its associated label from the coach registration form.